### PR TITLE
update project, link project in template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# xrpl-price-persist-oracle-sam
+# xrpl-price-persist-oracle
 
 ## Mainnet
 
 💳: `rEGGDggxupqxJ3ZbDTLUzKtpHxHyhtUtiU`
 <kbd>[🧭][mainnet-account-xrplf]</kbd>
 
-▶️: [![Mainnet](https://github.com/yyolk/xrpl-price-persist-oracle-sam/actions/workflows/mainnet.yml/badge.svg)](https://github.com/yyolk/xrpl-price-persist-oracle-sam/actions/workflows/mainnet.yml)
+▶️: [![Mainnet](https://github.com/yyolk/xrpl-price-persist-oracle/actions/workflows/mainnet.yml/badge.svg)](https://github.com/yyolk/xrpl-price-persist-oracle/actions/workflows/mainnet.yml)
 
 
 ## Testnet
@@ -13,12 +13,12 @@
 💳: `rayZw5nJmueB5ps2bfL85aJgiKub7FsVYN`
 <kbd>[🧭][testnet-account-xrplf]</kbd>
 
-▶️: [![Testnet](https://github.com/yyolk/xrpl-price-persist-oracle-sam/actions/workflows/testnet.yml/badge.svg)](https://github.com/yyolk/xrpl-price-persist-oracle-sam/actions/workflows/testnet.yml)
+▶️: [![Testnet](https://github.com/yyolk/xrpl-price-persist-oracle/actions/workflows/testnet.yml/badge.svg)](https://github.com/yyolk/xrpl-price-persist-oracle/actions/workflows/testnet.yml)
 
 
 ## Prices via Oracle
 
-🚧 Gaps indicate the oracle didn't *reliably* publish during this time see [#27](https://github.com/yyolk/xrpl-price-persist-oracle-sam/issues/27) 🚧
+🚧 Gaps indicate the oracle didn't *reliably* publish during this time see [#27](https://github.com/yyolk/xrpl-price-persist-oracle/issues/27) 🚧
 
 <div align="center">
 
@@ -138,7 +138,7 @@ This includes some additional costs if the function needs to cold start (assumin
 persisting the client in the outer scope for subsequent executions).
 (_see [Sharing Secrets with AWS Lambda Using AWS Systems Manager Parameter Store](https://aws.amazon.com/blogs/compute/sharing-secrets-with-aws-lambda-using-aws-systems-manager-parameter-store/)_)
 
-You'll want to attach a policy to the function like in [`5603945`](https://github.com/yyolk/xrpl-price-persist-oracle-sam/blob/c8982dddf080b0cf6a75907aad0467dc9e3b8dd4/template.yaml#L93-L95)
+You'll want to attach a policy to the function like in [`5603945`](https://github.com/yyolk/xrpl-price-persist-oracle/blob/c8982dddf080b0cf6a75907aad0467dc9e3b8dd4/template.yaml#L93-L95)
 include a policy attached to the `OracleFunction` resource under the
 `Properties` dict.
 

--- a/template.yaml
+++ b/template.yaml
@@ -8,6 +8,7 @@ AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: >-
   XRPL-Price-Persist-Oracle
+  https://github.com/yyolk/xrpl-price-persist-oracle
 
 Parameters:
   ScheduleInterval:


### PR DESCRIPTION
- prior to repository tags, the only way to get discoverability was to have the framework included in the name, i did this like i normally would but realized this isn't proprietary src code anymore and public namespaces are great
- i won't reuse the `xrpl-price-persist-oracle-sam` from my username namespace for the forseeable future so anything that was linking this in it's 8days in existence will get forwarded to the repo as expected, thanks github.

repo tags lets me drop that unnecessary information from the project name
![image](https://user-images.githubusercontent.com/134478/129849894-5dda941b-a0db-4033-a02c-ff11e45c3635.png)
