### PR TITLE
xrp-price-aggregate@0.0.13

### DIFF
--- a/oracle/requirements.txt
+++ b/oracle/requirements.txt
@@ -1,2 +1,2 @@
-xrp-price-aggregate==0.0.12
+xrp-price-aggregate==0.0.13
 xrpl-py


### PR DESCRIPTION

closes #34 

https://github.com/yyolk/xrp-price-aggregate/releases/tag/0.0.13

notably, threexrp.dev is temporarily dropped (see yyolk/xrp-price-aggregate#13)
