### PR TITLE
xrp-price-aggregate@0.0.14

### DIFF
--- a/oracle/requirements.txt
+++ b/oracle/requirements.txt
@@ -1,2 +1,2 @@
-xrp-price-aggregate==0.0.13
+xrp-price-aggregate==0.0.14
 xrpl-py~=1.1.1


### PR DESCRIPTION
```
xrp-price-aggregate@0.0.14
```

starts to address #27 - by filtering out at the time of failure any chains of providers requests. 
Platforms that respond to at least the initial request will be included in the aggregate results 

i.e.:
```
[ ❌ ] <~ won't be included
[ ✅ ✅ ❌ ] <~ will be included 👍 
[ ✅ ❌] <~ will be included 👍
[ ✅ ✅ ✅ ] <~ will be included 👍
```

see yyolk/xrp-price-aggregate#19 and https://github.com/yyolk/xrp-price-aggregate/releases/tag/0.0.14 This is a broad stroke. 