### PR TITLE
xrp-price-aggregate@0.0.15

### DIFF
--- a/oracle/requirements.txt
+++ b/oracle/requirements.txt
@@ -1,2 +1,2 @@
-xrp-price-aggregate==0.0.14
+xrp-price-aggregate==0.0.15
 xrpl-py~=1.1.1


### PR DESCRIPTION
this addresses a step missing in 0.0.14; it was non-breaking as the result was the same as the prior 0.0.13 release of any exceptions.


the summary is identical to #43

starts to address #27 - by filtering out at the time of failure any chains of providers requests. 
Platforms that respond to at least the initial request will be included in the aggregate results 

i.e.:
```
[ ❌ ] <~ won't be included
[ ✅ ✅ ❌ ] <~ will be included 👍 
[ ✅ ❌] <~ will be included 👍
[ ✅ ✅ ✅ ] <~ will be included 👍
```

see yyolk/xrp-price-aggregate#20 https://github.com/yyolk/xrp-price-aggregate/releases/tag/0.0.15 for more info