### PR TITLE
dont check_fee at autofill

### DIFF
--- a/oracle/contract.py
+++ b/oracle/contract.py
@@ -219,7 +219,7 @@ def handler(
     )
     # Sign the transaction
     trustset_tx_signed = safe_sign_and_autofill_transaction(
-        trustset_tx, wallet, xrpl_client
+        transaction=trustset_tx, wallet=wallet, client=xrpl_client, check_fee=False
     )
 
     try:


### PR DESCRIPTION
don't check_fee (default=True) which might be getting us throttled at our freq.. 


on function invocation we cache this for subsequent re-use.

from main, prior to this merge: https://github.com/yyolk/xrpl-price-persist-oracle/blob/4895a1f1484d53f85e527d4619415fbc4c48a044/oracle/contract.py#L45