### PR TITLE
update rpc url for mainnet

### DIFF
--- a/.github/workflows/mainnet.yml
+++ b/.github/workflows/mainnet.yml
@@ -12,7 +12,8 @@ jobs:
       name: mainnet
       url: https://explorer.xrplf.org/rEGGEgg9hQSHLxUwycGnmjW2GKX9thn2yH
     env:
-      XRPL_NODE_JSON_RPC_URL: https://xrplcluster.com
+      # XRPL_NODE_JSON_RPC_URL: https://xrplcluster.com
+      XRPL_NODE_JSON_RPC_URL: https://s1.ripple.com:51234/
       XRPL_NODE_ENVIRONMENT: Mainnet
       STACK_NAME: xrpl-price-persist-oracle-mainnet
     runs-on: ubuntu-latest


### PR DESCRIPTION
xrplcluster.com responds with a message when being throttled that creates an avalanche of failures. 

In the interim until my node is available, I may have to swap between json-rpc urls

This should resolve the non-reporting gaps over the last 12 hours 

![image](https://user-images.githubusercontent.com/134478/134073779-ec94d0d1-a612-47ea-998e-47cfc69022e7.png)
![image](https://user-images.githubusercontent.com/134478/134073792-4dfd65d3-9d78-4705-b343-cbe0544fb6eb.png)
